### PR TITLE
Feature/mypage - 유저 게시글, 댓글 데이터 가져오기

### DIFF
--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -7,6 +7,11 @@ const Layout = ({ children }: { children: ReactNode }) => {
   //수정 클릭
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
+  //주스탄드 쓸 예정
+  const user = {
+    id: "6945ddb3-1281-4b59-b16c-f238709e37a9",
+    nickname: "수수수",
+  };
   return (
     <div className="p-10 gap-4">
       <div className="flex flex-row">
@@ -35,7 +40,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
       </div>
       <div className="bg-gray-700 m-8 py-10 text-xl text-white rounded-xl">
         <p className="pl-5 flex flex-row">
-          <p className="text-orange-500 font-bold pr-1">두두둥님, </p> 나의
+          <p className="text-orange-500 font-bold pr-1">{user.nickname}님</p>의
           질문과 답변을 모아보고 복습해보세요!
         </p>
       </div>

--- a/src/app/mypage/mycomments/page.tsx
+++ b/src/app/mypage/mycomments/page.tsx
@@ -1,11 +1,45 @@
-import Mycard from "@/components/(mypage)/Mycard";
+import supabase from "@/app/supabase/client";
+import Mycommentcard from "@/components/(mypage)/Mycommentcard";
 
-const mycomments = () => {
+//후에 주스탄드로 유저 정보 저장 및 가져올 것
+//user의 Nickname도 함께 저장 되어있으면 좋겠습니다.
+const user = {
+  id: "6945ddb3-1281-4b59-b16c-f238709e37a9",
+  nickname: "수수수",
+};
+
+const SUPABASE_TABLE_NAME = {
+  ANSWER: "answers",
+  COMMENTS: "comments",
+};
+
+const mycomments = async () => {
+  //게시글 불러오는 함수 (후에 커리에 넣을 예정)
+  const getuserpost = async (userid: string) => {
+    const { data, error } = await supabase
+      .from(SUPABASE_TABLE_NAME.COMMENTS)
+      .select(
+        `
+    *,
+    users(*)
+  `
+      )
+      .eq("comment_user_id", userid);
+    if (error) {
+      throw error;
+    }
+    return data;
+  };
+
+  const a = await getuserpost(user.id);
+
   return (
     <div>
       <hr className="border-t border-gray-400 my-6" />
       <div className="flex flex-col  ">
-        <Mycard />
+        {a?.map((aa) => {
+          return <Mycommentcard {...aa} key={aa.comment_id} />;
+        })}
       </div>
     </div>
   );

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,12 +1,45 @@
-import Mycard from "@/components/(mypage)/Mycard";
+import Myanswercard from "@/components/(mypage)/Myanswercard";
+import supabase from "../supabase/client";
 
-const MyPage = () => {
+//후에 주스탄드로 유저 정보 저장 및 가져올 것
+//user의 Nickname도 함께 저장 되어있으면 좋겠습니다.
+const user = {
+  id: "6945ddb3-1281-4b59-b16c-f238709e37a9",
+  nickname: "수수수",
+};
+
+const SUPABASE_TABLE_NAME = {
+  ANSWER: "answers",
+  COMMENTS: "comments",
+};
+
+const MyPage = async () => {
+  //게시글 불러오는 함수 (후에 커리에 넣을 예정)
+  const getuserpost = async (userid: string) => {
+    const { data, error } = await supabase
+      .from(SUPABASE_TABLE_NAME.ANSWER)
+      .select(
+        `
+      *,
+      users(*)
+    `
+      )
+      .eq("answer_user_id", userid);
+    if (error) {
+      throw error;
+    }
+    return data;
+  };
+
+  const a = await getuserpost(user.id);
+
   return (
     <div>
       <hr className="border-t border-gray-400 my-6" />
       <div className="flex flex-col  ">
-        <Mycard />
-        <Mycard />
+        {a?.map((aa) => {
+          return <Myanswercard {...aa} key={aa.answer_id} />;
+        })}
       </div>
     </div>
   );

--- a/src/components/(mypage)/Myanswercard.tsx
+++ b/src/components/(mypage)/Myanswercard.tsx
@@ -1,9 +1,18 @@
-const Mycard = () => {
+type Answer = {
+  answer_id: string;
+  answer_create_at: string;
+  answer_image: string | null;
+  answer_text: string;
+  answer_answer: string;
+  answer_user_id: string;
+};
+
+const Mycard = (answer: Answer) => {
   return (
     <div className="flex flex-row m-10 w-80% justify-center text-center">
       <div className="flex-1">
-        <div className="text-xl font-bold">제목자리</div>
-        <div>내용자리</div>
+        <div className="text-xl font-bold">{answer.answer_text}</div>
+        <div>{answer.answer_answer}</div>
         <div className="flex flex-row gap-3 justify-left ml-5">
           <button className="border-2 border-orange-500 rounded-l p-1">
             수정
@@ -13,7 +22,14 @@ const Mycard = () => {
           </button>
         </div>
       </div>
-      <div className="border-2 border-white rounded-l flex-2">이미지 자리</div>
+      {!answer.answer_image ? (
+        <div className="flex-2"></div>
+      ) : (
+        <div className="border-2 border-white rounded-l flex-2">
+          이미지 자리
+        </div>
+      )}
+
       <div className="flex-5">화살표 자리</div>
     </div>
   );

--- a/src/components/(mypage)/Mycommentcard.tsx
+++ b/src/components/(mypage)/Mycommentcard.tsx
@@ -1,19 +1,17 @@
 //다른 분 pr에 타입파일 새로 만드신거 있길래 일단 여기 넣어뒀습니다.
-type Answer = {
-  answer_id: string;
-  answer_create_at: string;
-  answer_image: string | null;
-  answer_text: string;
-  answer_answer: string;
-  answer_user_id: string;
+type Comment = {
+  comment_created_at: string;
+  comment_content: string;
+  comment_user_id: string;
+  comment_id: string;
+  comment_answer_id: string;
 };
 
-const Mycard = (answer: Answer) => {
+const Mycommentcard = (comment: Comment) => {
   return (
     <div className="flex flex-row m-10 w-80% justify-center text-center">
-      <div className="flex-1">
-        <div className="text-xl font-bold">{answer.answer_text}</div>
-        <div>{answer.answer_answer}</div>
+      <div className="flex-1 ">
+        <div className="text-xl font-bold mb-5">{comment.comment_content}</div>
         <div className="flex flex-row gap-3 justify-left ml-5">
           <button className="border-2 border-orange-500 rounded-l p-1">
             수정
@@ -23,17 +21,9 @@ const Mycard = (answer: Answer) => {
           </button>
         </div>
       </div>
-      {!answer.answer_image ? (
-        <div className="flex-2"></div>
-      ) : (
-        <div className="border-2 border-white rounded-l flex-2">
-          이미지 자리
-        </div>
-      )}
-
       <div className="flex-5">화살표 자리</div>
     </div>
   );
 };
 
-export default Mycard;
+export default Mycommentcard;


### PR DESCRIPTION
📣
변경사항:
댓글 카드 컴포넌트 추가
주스탄드 대비 받아올 값을 기준으로 나타내기
수파베이스 연결  >  유저 기준 게시글, 댓글 가져옴 

⭕
구현 기능:
탭 이동 시, 나의 게시글, 댓글을 모아 볼 수 있음

❌
현재 문제:
수파베이스에 이미지가 없어 나타내는 거 구현 못함
(추후 목 데이터 추가하여 시도할 예정)
지정된 색으로 진행하지 않음

✨공유 사항
1. type 다른 분 pr에 있길래 해당 부분 pr 올라오면 합칠려고 일단 제 파일에 적어두었습니다.
2. 게시글 그리고 댓글 가져오는 부분의 수파베이스 코드를 한 파일에 작성하고자 하는데 어떤가요?
3. 댓글 부분에 어떤 것을 나타내는 것이 좋을까요?
 - 테이블을 보니 이미지, 제목이 없어서 내용만 가져오는데 이것만해도 충분할까요? 


☺️
스크린샷
![0](https://github.com/user-attachments/assets/3fbcba56-af86-4d65-94a1-3b4388e5961c)

