### PR TITLE
🩹 fix: sweetalert로 알림창 변경, useEffect 의존성 추가

### DIFF
--- a/src/components/(login,signup)/LoginForm.tsx
+++ b/src/components/(login,signup)/LoginForm.tsx
@@ -6,6 +6,7 @@ import { useForm, SubmitHandler } from "react-hook-form";
 import Link from "next/link";
 import supabase from "@/app/supabase/client";
 import { useAuthStore } from "@/stores/store";
+import { AlertError } from "@/utils/alert";
 
 interface LoginFormData {
   email: string;
@@ -42,14 +43,14 @@ const LoginForm = () => {
       return;
     }
   };
-  
+
   // 로그인 상태일때 로그인페이지로 가는 걸 막는 로직
   useEffect(() => {
     if (user) {
-      alert("잘못된 접근입니다.");
+      AlertError("잘못된 접근입니다.");
       router.push("/");
     }
-  }, []);
+  }, [router, user]);
 
   return (
     <div className="w-[400px] bg-neutral-800 text-white p-8 rounded-lg shadow-lg">


### PR DESCRIPTION
변경사항: sweetalert 알림창으로 변경
useEffect 의존성 추가 - yarn build를 했는데 추가 하라는 오류메시지가 떠서 추가 함
🤖 이유
🔹 user를 넣어야 하는 이유
user 값이 변경될 때마다 useEffect가 다시 실행되어, 사용자가 로그인 상태인지 체크하는 로직이 정상적으로 작동함.
예를 들어 user 상태가 null이었다가 로그인 후 user 객체가 설정되면, useEffect가 실행되지 않으면 /로 리디렉트되지 않음.

🔹 router를 넣어야 하는 이유
Next.js의 useRouter()는 클라이언트 측에서 사용하는 훅이므로 라우터 객체(router)가 변경될 가능성이 있음.

Next.js는 자동으로 최적화 및 정적 분석을 수행하는데, router.push("/")를 실행하는 부분이 useEffect 내부에 있지만 router가 의존성 배열에 없으면 빌드 시점에 예측할 수 없는 동작이 발생할 가능성이 있다고 판단하여 경고를 띄우는 것이야.

<img width="1204" alt="image" src="https://github.com/user-attachments/assets/642187ce-3a58-478d-aebf-69ae65fcb1b0" />
